### PR TITLE
Move FAST, FASTSourceCode and FASTDump tabs after Navigation

### DIFF
--- a/src/FAST-Core-Model-Extension/FASTTEntity.extension.st
+++ b/src/FAST-Core-Model-Extension/FASTTEntity.extension.st
@@ -29,17 +29,18 @@ FASTTEntity >> display [
 { #category : #'*FAST-Core-Model-Extension' }
 FASTTEntity >> inspectionFAST [
 
-	<inspectorPresentationOrder: 450 title: 'FAST'>
+	<inspectorPresentationOrder: 1.1 title: 'FAST'>
 	^ SpTreeTablePresenter new
 		  addColumn: (SpCompositeTableColumn new
 				   addColumn: ((SpImageTableColumn evaluated: #mooseIcon)
 						    width: 20;
 						    yourself);
-				   addColumn: (SpStringTableColumn evaluated: [ :node | node display ]);
+				   addColumn:
+				   (SpStringTableColumn evaluated: [ :node | node display ]);
 				   yourself);
-		  children: [ :aClass | 
-			  aClass children asArray sorted: [ :a :b | 
-				  (a startPos ifNil: 0) <= (b startPos ifNil: 0) ] ];
+		  children: [ :aClass |
+			  aClass children asArray sorted: [ :a :b |
+				  (a startPos ifNil: [ 0 ]) <= (b startPos ifNil: [ 0 ]) ] ];
 		  beMultipleSelection;
 		  roots: { self };
 		  beResizable
@@ -48,9 +49,9 @@ FASTTEntity >> inspectionFAST [
 { #category : #'*FAST-Core-Model-Extension' }
 FASTTEntity >> inspectionFASTSourceCode [
 
-	<inspectorPresentationOrder: 500 title: 'FASTSourceCode'>
-	(self sourceText isNotNil and: [ 
-		 self startPos isNotNil and: [ self endPos isNotNil ] ]) ifFalse: [ 
+	<inspectorPresentationOrder: 1.2 title: 'FASTSourceCode'>
+	(self sourceText isNotNil and: [
+		 self startPos isNotNil and: [ self endPos isNotNil ] ]) ifFalse: [
 		^ SpTextPresenter new
 			  text: 'Not available';
 			  yourself ].

--- a/src/FAST-Core-Tools/FASTTEntity.extension.st
+++ b/src/FAST-Core-Tools/FASTTEntity.extension.st
@@ -19,7 +19,7 @@ FASTTEntity >> dump [
 { #category : #'*FAST-Core-Tools' }
 FASTTEntity >> inspectionFASTDump [
 
-	<inspectorPresentationOrder: 550 title: 'FASTDump'>
+	<inspectorPresentationOrder: 1.3 title: 'FASTDump'>
 	^ SpCodePresenter new
 		  text: (RBParser parseExpression: self dump) formattedCode;
 		  beForScripting;


### PR DESCRIPTION
New order:
![image](https://github.com/moosetechnology/FAST/assets/78592838/b31545ea-c432-4aa1-af6a-645eae688398)

Old order:
![image](https://github.com/moosetechnology/FAST/assets/78592838/87ef6fe2-c073-48b7-b8b3-075f33bb1a4d)

