### PR TITLE
In FASTCopyVisitorCodeGenerator, categorized generated method in #vis…

### DIFF
--- a/src/FAST-Core-Tools/FASTCopyVisitorCodeGenerator.class.st
+++ b/src/FAST-Core-Tools/FASTCopyVisitorCodeGenerator.class.st
@@ -109,7 +109,7 @@ FASTCopyVisitorCodeGenerator >> generateVisit: aModelClass in: aVisitorClass [
 		self generateVisitBody: aModelClass in: outputStream.
 	].
 
-	aVisitorClass compile: code classified: Protocol unclassified
+	aVisitorClass compile: code classified: #visiting
 ]
 
 { #category : #'code generation' }


### PR DESCRIPTION
…iting rather than Unclassified