### PR TITLE
added an 'All' group to baselineof because this is a default in Iceberg

### DIFF
--- a/src/BaselineOfFAST/BaselineOfFAST.class.st
+++ b/src/BaselineOfFAST/BaselineOfFAST.class.st
@@ -41,8 +41,11 @@ BaselineOfFAST >> defineGroups: spec [
 		group: 'core'
 		with: #( 'FAST-Core-Model' 'FAST-Core-Model-Extension' 'FAST-Model-Generator'  'FAST-Core-Visitor' ) ;
 
-		group: 'tools'
+		group: 'All'
 		with: #( 'core' 'FAST-Core-Tools' 'FAST-Core-Tools-Tests' ) ;
+
+		group: 'tools'
+		with: #( 'All' ) ;
 
 		group: 'default' with: #( 'core' )
 


### PR DESCRIPTION
feat: added an 'All' group to baselineof because this is a default in Iceberg