### PR TITLE
FIx baseline

### DIFF
--- a/src/BaselineOfFAST/BaselineOfFAST.class.st
+++ b/src/BaselineOfFAST/BaselineOfFAST.class.st
@@ -28,27 +28,23 @@ BaselineOfFAST >> customProjectAttributes [
 { #category : 'baselines' }
 BaselineOfFAST >> defineDependencies: spec [
 
-	spec for: #NeedsMoose do: [ 
-		spec baseline: 'Famix' with: [ 
-			spec
-				loads: #( 'Basic' );
-				repository: 'github://moosetechnology/Famix:development/src' ] ]
+	spec for: #NeedsMoose do: [
+			spec baseline: 'Famix' with: [
+					spec
+						loads: #( 'Basic' 'BasicTraits' );
+						repository: 'github://moosetechnology/Famix:development/src' ].
+
+			spec project: 'FamixTests' copyFrom: 'Famix' with: [ spec loads: 'Tests' ] ]
 ]
 
 { #category : 'baselines' }
 BaselineOfFAST >> defineGroups: spec [
+
 	spec
-		group: 'core'
-		with: #( 'FAST-Core-Model' 'FAST-Core-Model-Extension' 'FAST-Model-Generator'  'FAST-Core-Visitor' ) ;
-
-		group: 'All'
-		with: #( 'core' 'FAST-Core-Tools' 'FAST-Core-Tools-Tests' ) ;
-
-		group: 'tools'
-		with: #( 'All' ) ;
-
+		group: 'core' with: #( 'FAST-Core-Model' 'FAST-Core-Model-Extension' 'FAST-Model-Generator' 'FAST-Core-Visitor' );
+		group: 'All' with: #( 'core' 'FAST-Core-Tools' 'FAST-Core-Tools-Tests' );
+		group: 'tools' with: #( 'All' );
 		group: 'default' with: #( 'core' )
-
 ]
 
 { #category : 'baselines' }
@@ -56,20 +52,16 @@ BaselineOfFAST >> definePackages: spec [
 
 	spec
 		package: 'FAST-Core-Model';
-		package: 'FAST-Core-Model-Extension'
-		with: [ spec requires: #( 'FAST-Core-Model' ) ];
-		package: 'FAST-Core-Visitor'
-		with: [ spec requires: #( 'FAST-Core-Model' ) ];
+		package: 'FAST-Core-Model-Extension' with: [ spec requires: #( 'FAST-Core-Model' ) ];
+		package: 'FAST-Core-Visitor' with: [ spec requires: #( 'FAST-Core-Model' ) ];
 		package: 'FAST-Model-Generator';
-		package: 'FAST-Core-Tools'
-		with: [ spec requires: #( 'FAST-Core-Visitor' ) ];
-		package: 'FAST-Core-Tools-Tests'
-		with: [ spec requires: #( 'FAST-Core-Tools' ) ];
+		package: 'FAST-Core-Tools' with: [ spec requires: #( 'FAST-Core-Visitor' ) ];
+		package: 'FAST-Core-Tools-Tests' with: [ spec requires: #( 'FAST-Core-Tools' ) ];
 		package: 'FAST-Core-Deprecated'.
 
-	spec for: #NeedsMoose do: [ 
-		spec
-			package: 'FAST-Core-Model' with: [ spec requires: #( 'Famix' ) ];
-			package: 'FAST-Model-Generator'
-			with: [ spec requires: #( 'Famix' ) ] ]
+	spec for: #NeedsMoose do: [
+			spec
+				package: 'FAST-Core-Model' with: [ spec requires: #( 'Famix' ) ];
+				package: 'FAST-Model-Generator' with: [ spec requires: #( 'Famix' ) ];
+				package: 'FAST-Core-Tools-Tests' with: [ spec requires: #( 'FamixTests' ) ] ]
 ]


### PR DESCRIPTION
- FAST needs Famix-Traits but was not loading them
- FAST tests needs some classes in Famix's tests but was not declaring it as dependency (In fact we bring a huge amount of code just for those tests. I think they should be rewritten to avoid the dependency)