### PR TITLE
Split TBehavioral and TWithStatements

### DIFF
--- a/src/FAST-Core-Model/FASTEntity.class.st
+++ b/src/FAST-Core-Model/FASTEntity.class.st
@@ -35,10 +35,3 @@ FASTEntity class >> metamodel [
 	<generated>
 	^ FASTModel metamodel
 ]
-
-{ #category : 'testing' }
-FASTEntity >> isQueryable [
-
-	<generated>
-	^ false
-]

--- a/src/FAST-Core-Model/FASTTBehaviouralEntity.trait.st
+++ b/src/FAST-Core-Model/FASTTBehaviouralEntity.trait.st
@@ -14,7 +14,7 @@ Local variables are intended to be stored in the local entities of the body
 | Relation | Origin | Opposite | Type | Comment |
 |---|
 | `parameters` | `FASTTWithParameters` | `parameterOwner` | `FASTTVariableEntity` | My parameters|
-| `statementBlock` | `FASTTBehaviouralEntity` | `fastBehaviouralParent` | `FASTTStatementBlock` | Statements block of the behavioural entity|
+| `statementBlock` | `FASTTWithStatements` | `fastBehaviouralParent` | `FASTTStatementBlock` | Statements block of the behavioural entity|
 
 
 ## Properties
@@ -28,11 +28,8 @@ Local variables are intended to be stored in the local entities of the body
 "
 Trait {
 	#name : 'FASTTBehaviouralEntity',
-	#instVars : [
-		'#statementBlock => FMOne type: #FASTTStatementBlock opposite: #fastBehaviouralParent'
-	],
-	#traits : 'FASTTScopableEntity + FASTTWithParameters',
-	#classTraits : 'FASTTScopableEntity classTrait + FASTTWithParameters classTrait',
+	#traits : 'FASTTScopableEntity + FASTTWithParameters + FASTTWithStatements',
+	#classTraits : 'FASTTScopableEntity classTrait + FASTTWithParameters classTrait + FASTTWithStatements classTrait',
 	#category : 'FAST-Core-Model-Traits',
 	#package : 'FAST-Core-Model',
 	#tag : 'Traits'
@@ -52,27 +49,4 @@ FASTTBehaviouralEntity >> isBehaviouralEntity [
 
 	<generated>
 	^ true
-]
-
-{ #category : 'accessing' }
-FASTTBehaviouralEntity >> statementBlock [
-	"Relation named: #statementBlock type: #FASTTStatementBlock opposite: #fastBehaviouralParent"
-
-	<generated>
-	<FMComment: 'Statements block of the behavioural entity'>
-	^ statementBlock
-]
-
-{ #category : 'accessing' }
-FASTTBehaviouralEntity >> statementBlock: anObject [
-
-	<generated>
-	statementBlock := anObject
-]
-
-{ #category : 'navigation' }
-FASTTBehaviouralEntity >> statementBlockGroup [
-	<generated>
-	<navigation: 'StatementBlock'>
-	^ MooseSpecializedGroup with: self statementBlock
 ]

--- a/src/FAST-Core-Model/FASTTNamedBehaviouralEntity.trait.st
+++ b/src/FAST-Core-Model/FASTTNamedBehaviouralEntity.trait.st
@@ -18,7 +18,7 @@ Assumed to correspond to a function or a method
 | Relation | Origin | Opposite | Type | Comment |
 |---|
 | `parameters` | `FASTTWithParameters` | `parameterOwner` | `FASTTVariableEntity` | My parameters|
-| `statementBlock` | `FASTTBehaviouralEntity` | `fastBehaviouralParent` | `FASTTStatementBlock` | Statements block of the behavioural entity|
+| `statementBlock` | `FASTTWithStatements` | `fastBehaviouralParent` | `FASTTStatementBlock` | Statements block of the behavioural entity|
 
 
 ## Properties

--- a/src/FAST-Core-Model/FASTTStatementBlock.trait.st
+++ b/src/FAST-Core-Model/FASTTStatementBlock.trait.st
@@ -7,7 +7,7 @@ A block of statements as ones in C-like langs with {}
 ### Parents
 | Relation | Origin | Opposite | Type | Comment |
 |---|
-| `fastBehaviouralParent` | `FASTTStatementBlock` | `statementBlock` | `FASTTBehaviouralEntity` | Behavioural entity containing the statement block.|
+| `fastBehaviouralParent` | `FASTTStatementBlock` | `statementBlock` | `FASTTWithStatements` | Behavioural entity containing the statement block.|
 | `parentLoopStatement` | `FASTTStatement` | `body` | `FASTTLoopStatement` | Optional loop of which this statement is the body|
 | `statementContainer` | `FASTTStatement` | `statements` | `FASTTStatementBlock` | Block containing this statement.|
 
@@ -29,7 +29,7 @@ A block of statements as ones in C-like langs with {}
 Trait {
 	#name : 'FASTTStatementBlock',
 	#instVars : [
-		'#fastBehaviouralParent => FMOne type: #FASTTBehaviouralEntity opposite: #statementBlock',
+		'#fastBehaviouralParent => FMOne type: #FASTTWithStatements opposite: #statementBlock',
 		'#statements => FMMany type: #FASTTStatement opposite: #statementContainer'
 	],
 	#traits : 'FASTTStatement',
@@ -56,7 +56,7 @@ FASTTStatementBlock >> addStatement: anObject [
 
 { #category : 'accessing' }
 FASTTStatementBlock >> fastBehaviouralParent [
-	"Relation named: #fastBehaviouralParent type: #FASTTBehaviouralEntity opposite: #statementBlock"
+	"Relation named: #fastBehaviouralParent type: #FASTTWithStatements opposite: #statementBlock"
 
 	<generated>
 	<FMComment: 'Behavioural entity containing the statement block.'>

--- a/src/FAST-Core-Model/FASTTWithStatements.trait.st
+++ b/src/FAST-Core-Model/FASTTWithStatements.trait.st
@@ -1,0 +1,53 @@
+"
+## Relations
+======================
+
+### Children
+| Relation | Origin | Opposite | Type | Comment |
+|---|
+| `statementBlock` | `FASTTWithStatements` | `fastBehaviouralParent` | `FASTTStatementBlock` | Statements block of the behavioural entity|
+
+
+
+"
+Trait {
+	#name : 'FASTTWithStatements',
+	#instVars : [
+		'#statementBlock => FMOne type: #FASTTStatementBlock opposite: #fastBehaviouralParent'
+	],
+	#category : 'FAST-Core-Model-Traits',
+	#package : 'FAST-Core-Model',
+	#tag : 'Traits'
+}
+
+{ #category : 'meta' }
+FASTTWithStatements classSide >> annotation [
+
+	<FMClass: #TWithStatements super: #Object>
+	<package: #'FAST-Core-Model'>
+	<generated>
+	^ self
+]
+
+{ #category : 'accessing' }
+FASTTWithStatements >> statementBlock [
+	"Relation named: #statementBlock type: #FASTTStatementBlock opposite: #fastBehaviouralParent"
+
+	<generated>
+	<FMComment: 'Statements block of the behavioural entity'>
+	^ statementBlock
+]
+
+{ #category : 'accessing' }
+FASTTWithStatements >> statementBlock: anObject [
+
+	<generated>
+	statementBlock := anObject
+]
+
+{ #category : 'navigation' }
+FASTTWithStatements >> statementBlockGroup [
+	<generated>
+	<navigation: 'StatementBlock'>
+	^ MooseSpecializedGroup with: self statementBlock
+]

--- a/src/FAST-Model-Generator/FASTMetamodelGenerator.class.st
+++ b/src/FAST-Model-Generator/FASTMetamodelGenerator.class.st
@@ -35,7 +35,8 @@ Class {
 		'tBinaryExpression',
 		'tUnaryExpression',
 		'tConditionalStatement',
-		'tLoopStatement'
+		'tLoopStatement',
+		'tWithStatements'
 	],
 	#category : 'FAST-Model-Generator',
 	#package : 'FAST-Model-Generator'
@@ -221,6 +222,7 @@ FASTMetamodelGenerator >> defineHierarchy [
 	
 	tBehaviouralEntity --|> tScopableEntity.
 	tBehaviouralEntity --|> tWithParameters.
+	tBehaviouralEntity --|> tWithStatements.
 
 	tStatement --|> tEntity.
 	tConditionalStatement --|> tStatement.
@@ -268,38 +270,29 @@ FASTMetamodelGenerator >> defineProperties [
 
 { #category : 'definition' }
 FASTMetamodelGenerator >> defineRelations [
+
 	super defineRelations.
 
 	((tAssignment property: #expression) comment: 'Assigned expression (rhs of assignment)')
-	<>- ((tExpression property: #assignedIn)
-		comment: 'Optional assignment where this expression is used').
+	<>- ((tExpression property: #assignedIn) comment: 'Optional assignment where this expression is used').
 
 	((tAssignment property: #variable) comment: 'An assigned variable (lhs of assignment)')
-	<>- ((tVariableEntity property: #parentAssignmentExpression)
-		comment: 'Optional assignment to the variable').
-
-	(((tBehaviouralEntity property: #statementBlock) comment: 'Statements block of the behavioural entity')
-	<>- ((tStatementBlock property: #fastBehaviouralParent)
-		comment: 'Behavioural entity containing the statement block.')) .
+	<>- ((tVariableEntity property: #parentAssignmentExpression) comment: 'Optional assignment to the variable').
 
 	((tBinaryExpression property: #leftOperand) comment: 'left part of a binary expression')
-	<>- ((tExpression property: #parentExpressionLeft)
-		comment: 'Parent (binary) expression of which I am left side').
+	<>- ((tExpression property: #parentExpressionLeft) comment: 'Parent (binary) expression of which I am left side').
 
 	((tBinaryExpression property: #rightOperand) comment: 'left part of the expression')
-	<>- ((tExpression property: #parentExpressionRight)
-		comment: 'Parent (binary) expression of which I am right side').
+	<>- ((tExpression property: #parentExpressionRight) comment: 'Parent (binary) expression of which I am right side').
 
 	((tComment property: #container) comment: 'Source code entity containing the comment')
-		*-<> ((tWithComments property: #comments)
-			comment: 'list of comments defined in the entity').
+	*-<> ((tWithComments property: #comments) comment: 'list of comments defined in the entity').
 
 	((tConditionalStatement property: #condition) comment: 'The boolean condition tested')
 	<>- ((tExpression property: #parentConditionalStatement) comment: 'Optional condition statement where this expression is used').
 
-	(((tExpressionStatement property: #expression) comment: 'The expression of the statement')
-	<>- ((tExpression property: #expressionStatementOwner)
-		comment: 'The expression statement that own me (if it''s the case')) .
+	((tExpressionStatement property: #expression) comment: 'The expression of the statement')
+	<>- ((tExpression property: #expressionStatementOwner) comment: 'The expression statement that own me (if it''s the case').
 
 	((tInvocation property: #invoked) comment: 'The name of the behavioural invoked')
 	<>- ((tNamedEntity property: #invokedIn) comment: 'Optional invocation where this name is used').
@@ -307,22 +300,21 @@ FASTMetamodelGenerator >> defineRelations [
 	((tLoopStatement property: #body) comment: 'The body of the loop')
 	<>- ((tStatement property: #parentLoopStatement) comment: 'Optional loop of which this statement is the body').
 
-	(((tReturnStatement property: #expression) comment: 'The expression returned')
-	<>- ((tExpression property: #returnOwner)
-		comment: 'The return statement that own the expression (if it''s the case)')) .
+	((tReturnStatement property: #expression) comment: 'The expression returned')
+	<>- ((tExpression property: #returnOwner) comment: 'The return statement that own the expression (if it''s the case)').
 
-	(((tStatement property: #statementContainer) comment: 'Block containing this statement.')
-	*-<> ((tStatementBlock property: #statements) comment: 'Statements enclosed in this block')) .
+	((tStatement property: #statementContainer) comment: 'Block containing this statement.')
+	*-<> ((tStatementBlock property: #statements) comment: 'Statements enclosed in this block').
 
 	((tUnaryExpression property: #expression) comment: '(sub-)expression in the unary expression')
 	<>- ((tExpression property: #parentExpression) comment: 'Parent (unary) expression').
 
-	((tWithParameters property: #parameters) comment: 'My parameters')
-	<>-* ((tVariableEntity property: #parameterOwner) comment: 'parameterOwner') . 
+	((tWithParameters property: #parameters) comment: 'My parameters') <>-* ((tVariableEntity property: #parameterOwner) comment: 'parameterOwner').
 
-	((tWithArguments property: #arguments) comment: 'My arguments')
-	<>-* ((tExpression property: #argumentOwner) comment: 'my owner') .
+	((tWithArguments property: #arguments) comment: 'My arguments') <>-* ((tExpression property: #argumentOwner) comment: 'my owner').
 
+	((tWithStatements property: #statementBlock) comment: 'Statements block of the behavioural entity')
+	<>- ((tStatementBlock property: #fastBehaviouralParent) comment: 'Behavioural entity containing the statement block.')
 ]
 
 { #category : 'definition' }
@@ -378,4 +370,5 @@ FASTMetamodelGenerator >> defineTraits [
 	tWithComments := builder newTraitNamed: #TWithComments.
 	tWithComments comment: self commentForTWithComments.
 	tWithParameters := builder newTraitNamed: #TWithParameters comment: 'I have parameters'.
+	tWithStatements := builder newTraitNamed: #TWithStatements.
 ]


### PR DESCRIPTION
TBehavioral adds things that not all entities with statements have. Ideally they should be removed from TBehavioral but currently this would require to update a lot of models