### PR TITLE
Introduce FASTTWithCondition

### DIFF
--- a/src/FAST-Core-Model/FASTTAssignment.trait.st
+++ b/src/FAST-Core-Model/FASTTAssignment.trait.st
@@ -10,7 +10,7 @@ A node representing an assignment
 | `argumentOwner` | `FASTTExpression` | `arguments` | `FASTTWithArguments` | my owner|
 | `assignedIn` | `FASTTExpression` | `expression` | `FASTTAssignment` | Optional assignment where this expression is used|
 | `expressionStatementOwner` | `FASTTExpression` | `expression` | `FASTTExpressionStatement` | The expression statement that own me (if it's the case|
-| `parentConditionalStatement` | `FASTTExpression` | `condition` | `FASTTConditionalStatement` | Optional condition statement where this expression is used|
+| `parentConditional` | `FASTTExpression` | `condition` | `FASTTWithCondition` | Optional condition statement/expression where this expression is used|
 | `parentExpression` | `FASTTExpression` | `expression` | `FASTTUnaryExpression` | Parent (unary) expression|
 | `parentExpressionLeft` | `FASTTExpression` | `leftOperand` | `FASTTBinaryExpression` | Parent (binary) expression of which I am left side|
 | `parentExpressionRight` | `FASTTExpression` | `rightOperand` | `FASTTBinaryExpression` | Parent (binary) expression of which I am right side|

--- a/src/FAST-Core-Model/FASTTBinaryExpression.trait.st
+++ b/src/FAST-Core-Model/FASTTBinaryExpression.trait.st
@@ -10,7 +10,7 @@ A trait representing a binary expression of a node of a source code.
 | `argumentOwner` | `FASTTExpression` | `arguments` | `FASTTWithArguments` | my owner|
 | `assignedIn` | `FASTTExpression` | `expression` | `FASTTAssignment` | Optional assignment where this expression is used|
 | `expressionStatementOwner` | `FASTTExpression` | `expression` | `FASTTExpressionStatement` | The expression statement that own me (if it's the case|
-| `parentConditionalStatement` | `FASTTExpression` | `condition` | `FASTTConditionalStatement` | Optional condition statement where this expression is used|
+| `parentConditional` | `FASTTExpression` | `condition` | `FASTTWithCondition` | Optional condition statement/expression where this expression is used|
 | `parentExpression` | `FASTTExpression` | `expression` | `FASTTUnaryExpression` | Parent (unary) expression|
 | `parentExpressionLeft` | `FASTTExpression` | `leftOperand` | `FASTTBinaryExpression` | Parent (binary) expression of which I am left side|
 | `parentExpressionRight` | `FASTTExpression` | `rightOperand` | `FASTTBinaryExpression` | Parent (binary) expression of which I am right side|

--- a/src/FAST-Core-Model/FASTTBooleanLiteral.trait.st
+++ b/src/FAST-Core-Model/FASTTBooleanLiteral.trait.st
@@ -10,7 +10,7 @@ A boolean literal
 | `argumentOwner` | `FASTTExpression` | `arguments` | `FASTTWithArguments` | my owner|
 | `assignedIn` | `FASTTExpression` | `expression` | `FASTTAssignment` | Optional assignment where this expression is used|
 | `expressionStatementOwner` | `FASTTExpression` | `expression` | `FASTTExpressionStatement` | The expression statement that own me (if it's the case|
-| `parentConditionalStatement` | `FASTTExpression` | `condition` | `FASTTConditionalStatement` | Optional condition statement where this expression is used|
+| `parentConditional` | `FASTTExpression` | `condition` | `FASTTWithCondition` | Optional condition statement/expression where this expression is used|
 | `parentExpression` | `FASTTExpression` | `expression` | `FASTTUnaryExpression` | Parent (unary) expression|
 | `parentExpressionLeft` | `FASTTExpression` | `leftOperand` | `FASTTBinaryExpression` | Parent (binary) expression of which I am left side|
 | `parentExpressionRight` | `FASTTExpression` | `rightOperand` | `FASTTBinaryExpression` | Parent (binary) expression of which I am right side|

--- a/src/FAST-Core-Model/FASTTCharacterLiteral.trait.st
+++ b/src/FAST-Core-Model/FASTTCharacterLiteral.trait.st
@@ -10,7 +10,7 @@ A character literal
 | `argumentOwner` | `FASTTExpression` | `arguments` | `FASTTWithArguments` | my owner|
 | `assignedIn` | `FASTTExpression` | `expression` | `FASTTAssignment` | Optional assignment where this expression is used|
 | `expressionStatementOwner` | `FASTTExpression` | `expression` | `FASTTExpressionStatement` | The expression statement that own me (if it's the case|
-| `parentConditionalStatement` | `FASTTExpression` | `condition` | `FASTTConditionalStatement` | Optional condition statement where this expression is used|
+| `parentConditional` | `FASTTExpression` | `condition` | `FASTTWithCondition` | Optional condition statement/expression where this expression is used|
 | `parentExpression` | `FASTTExpression` | `expression` | `FASTTUnaryExpression` | Parent (unary) expression|
 | `parentExpressionLeft` | `FASTTExpression` | `leftOperand` | `FASTTBinaryExpression` | Parent (binary) expression of which I am left side|
 | `parentExpressionRight` | `FASTTExpression` | `rightOperand` | `FASTTBinaryExpression` | Parent (binary) expression of which I am right side|

--- a/src/FAST-Core-Model/FASTTConditionalStatement.trait.st
+++ b/src/FAST-Core-Model/FASTTConditionalStatement.trait.st
@@ -13,7 +13,7 @@ I represent any statement that has a boolean condition (eg. ifStatement)
 ### Children
 | Relation | Origin | Opposite | Type | Comment |
 |---|
-| `condition` | `FASTTConditionalStatement` | `parentConditionalStatement` | `FASTTExpression` | The boolean condition tested|
+| `condition` | `FASTTWithCondition` | `parentConditional` | `FASTTExpression` | The boolean condition tested|
 
 
 ## Properties
@@ -27,11 +27,8 @@ I represent any statement that has a boolean condition (eg. ifStatement)
 "
 Trait {
 	#name : 'FASTTConditionalStatement',
-	#instVars : [
-		'#condition => FMOne type: #FASTTExpression opposite: #parentConditionalStatement'
-	],
-	#traits : 'FASTTStatement',
-	#classTraits : 'FASTTStatement classTrait',
+	#traits : 'FASTTStatement + FASTTWithCondition',
+	#classTraits : 'FASTTStatement classTrait + FASTTWithCondition classTrait',
 	#category : 'FAST-Core-Model-Traits',
 	#package : 'FAST-Core-Model',
 	#tag : 'Traits'
@@ -44,27 +41,4 @@ FASTTConditionalStatement classSide >> annotation [
 	<package: #'FAST-Core-Model'>
 	<generated>
 	^ self
-]
-
-{ #category : 'accessing' }
-FASTTConditionalStatement >> condition [
-	"Relation named: #condition type: #FASTTExpression opposite: #parentConditionalStatement"
-
-	<generated>
-	<FMComment: 'The boolean condition tested'>
-	^ condition
-]
-
-{ #category : 'accessing' }
-FASTTConditionalStatement >> condition: anObject [
-
-	<generated>
-	condition := anObject
-]
-
-{ #category : 'navigation' }
-FASTTConditionalStatement >> conditionGroup [
-	<generated>
-	<navigation: 'Condition'>
-	^ MooseSpecializedGroup with: self condition
 ]

--- a/src/FAST-Core-Model/FASTTExpression.trait.st
+++ b/src/FAST-Core-Model/FASTTExpression.trait.st
@@ -10,7 +10,7 @@ An abstract superclass representing an expression node of a source code.
 | `argumentOwner` | `FASTTExpression` | `arguments` | `FASTTWithArguments` | my owner|
 | `assignedIn` | `FASTTExpression` | `expression` | `FASTTAssignment` | Optional assignment where this expression is used|
 | `expressionStatementOwner` | `FASTTExpression` | `expression` | `FASTTExpressionStatement` | The expression statement that own me (if it's the case|
-| `parentConditionalStatement` | `FASTTExpression` | `condition` | `FASTTConditionalStatement` | Optional condition statement where this expression is used|
+| `parentConditional` | `FASTTExpression` | `condition` | `FASTTWithCondition` | Optional condition statement/expression where this expression is used|
 | `parentExpression` | `FASTTExpression` | `expression` | `FASTTUnaryExpression` | Parent (unary) expression|
 | `parentExpressionLeft` | `FASTTExpression` | `leftOperand` | `FASTTBinaryExpression` | Parent (binary) expression of which I am left side|
 | `parentExpressionRight` | `FASTTExpression` | `rightOperand` | `FASTTBinaryExpression` | Parent (binary) expression of which I am right side|
@@ -29,14 +29,14 @@ An abstract superclass representing an expression node of a source code.
 Trait {
 	#name : 'FASTTExpression',
 	#instVars : [
+		'#argumentOwner => FMOne type: #FASTTWithArguments opposite: #arguments',
 		'#assignedIn => FMOne type: #FASTTAssignment opposite: #expression',
+		'#expressionStatementOwner => FMOne type: #FASTTExpressionStatement opposite: #expression',
+		'#parentConditional => FMOne type: #FASTTWithCondition opposite: #condition',
+		'#parentExpression => FMOne type: #FASTTUnaryExpression opposite: #expression',
 		'#parentExpressionLeft => FMOne type: #FASTTBinaryExpression opposite: #leftOperand',
 		'#parentExpressionRight => FMOne type: #FASTTBinaryExpression opposite: #rightOperand',
-		'#parentConditionalStatement => FMOne type: #FASTTConditionalStatement opposite: #condition',
-		'#expressionStatementOwner => FMOne type: #FASTTExpressionStatement opposite: #expression',
-		'#returnOwner => FMOne type: #FASTTReturnStatement opposite: #expression',
-		'#parentExpression => FMOne type: #FASTTUnaryExpression opposite: #expression',
-		'#argumentOwner => FMOne type: #FASTTWithArguments opposite: #arguments'
+		'#returnOwner => FMOne type: #FASTTReturnStatement opposite: #expression'
 	],
 	#traits : 'FASTTEntity',
 	#classTraits : 'FASTTEntity classTrait',
@@ -136,28 +136,35 @@ FASTTExpression >> isExpression [
 ]
 
 { #category : 'accessing' }
-FASTTExpression >> parentConditionalStatement [
-	"Relation named: #parentConditionalStatement type: #FASTTConditionalStatement opposite: #condition"
+FASTTExpression >> parentConditional [
+	"Relation named: #parentConditional type: #FASTTWithCondition opposite: #condition"
 
 	<generated>
-	<FMComment: 'Optional condition statement where this expression is used'>
+	<FMComment: 'Optional condition statement/expression where this expression is used'>
 	<container>
 	<derived>
-	^ parentConditionalStatement
+	^ parentConditional
 ]
 
 { #category : 'accessing' }
-FASTTExpression >> parentConditionalStatement: anObject [
+FASTTExpression >> parentConditional: anObject [
 
 	<generated>
-	parentConditionalStatement := anObject
+	parentConditional := anObject
 ]
 
 { #category : 'navigation' }
-FASTTExpression >> parentConditionalStatementGroup [
+FASTTExpression >> parentConditionalGroup [
 	<generated>
-	<navigation: 'ParentConditionalStatement'>
-	^ MooseSpecializedGroup with: self parentConditionalStatement
+	<navigation: 'ParentConditional'>
+	^ MooseSpecializedGroup with: self parentConditional
+]
+
+{ #category : 'accessing' }
+FASTTExpression >> parentConditionalStatement [
+
+	self deprecated: 'Use #parentConditional instead.' transformWith: '`@rcv parentConditionalStatement' -> '`@rcv parentConditional'.
+	^ self parentConditional
 ]
 
 { #category : 'accessing' }

--- a/src/FAST-Core-Model/FASTTInvocation.trait.st
+++ b/src/FAST-Core-Model/FASTTInvocation.trait.st
@@ -10,7 +10,7 @@ A invocation of a behavioural entity
 | `argumentOwner` | `FASTTExpression` | `arguments` | `FASTTWithArguments` | my owner|
 | `assignedIn` | `FASTTExpression` | `expression` | `FASTTAssignment` | Optional assignment where this expression is used|
 | `expressionStatementOwner` | `FASTTExpression` | `expression` | `FASTTExpressionStatement` | The expression statement that own me (if it's the case|
-| `parentConditionalStatement` | `FASTTExpression` | `condition` | `FASTTConditionalStatement` | Optional condition statement where this expression is used|
+| `parentConditional` | `FASTTExpression` | `condition` | `FASTTWithCondition` | Optional condition statement/expression where this expression is used|
 | `parentExpression` | `FASTTExpression` | `expression` | `FASTTUnaryExpression` | Parent (unary) expression|
 | `parentExpressionLeft` | `FASTTExpression` | `leftOperand` | `FASTTBinaryExpression` | Parent (binary) expression of which I am left side|
 | `parentExpressionRight` | `FASTTExpression` | `rightOperand` | `FASTTBinaryExpression` | Parent (binary) expression of which I am right side|

--- a/src/FAST-Core-Model/FASTTLiteral.trait.st
+++ b/src/FAST-Core-Model/FASTTLiteral.trait.st
@@ -15,7 +15,7 @@ FLAG: should refactor some literals to core-model
 | `argumentOwner` | `FASTTExpression` | `arguments` | `FASTTWithArguments` | my owner|
 | `assignedIn` | `FASTTExpression` | `expression` | `FASTTAssignment` | Optional assignment where this expression is used|
 | `expressionStatementOwner` | `FASTTExpression` | `expression` | `FASTTExpressionStatement` | The expression statement that own me (if it's the case|
-| `parentConditionalStatement` | `FASTTExpression` | `condition` | `FASTTConditionalStatement` | Optional condition statement where this expression is used|
+| `parentConditional` | `FASTTExpression` | `condition` | `FASTTWithCondition` | Optional condition statement/expression where this expression is used|
 | `parentExpression` | `FASTTExpression` | `expression` | `FASTTUnaryExpression` | Parent (unary) expression|
 | `parentExpressionLeft` | `FASTTExpression` | `leftOperand` | `FASTTBinaryExpression` | Parent (binary) expression of which I am left side|
 | `parentExpressionRight` | `FASTTExpression` | `rightOperand` | `FASTTBinaryExpression` | Parent (binary) expression of which I am right side|

--- a/src/FAST-Core-Model/FASTTNullPointerLiteral.trait.st
+++ b/src/FAST-Core-Model/FASTTNullPointerLiteral.trait.st
@@ -10,7 +10,7 @@ An undefined object literal
 | `argumentOwner` | `FASTTExpression` | `arguments` | `FASTTWithArguments` | my owner|
 | `assignedIn` | `FASTTExpression` | `expression` | `FASTTAssignment` | Optional assignment where this expression is used|
 | `expressionStatementOwner` | `FASTTExpression` | `expression` | `FASTTExpressionStatement` | The expression statement that own me (if it's the case|
-| `parentConditionalStatement` | `FASTTExpression` | `condition` | `FASTTConditionalStatement` | Optional condition statement where this expression is used|
+| `parentConditional` | `FASTTExpression` | `condition` | `FASTTWithCondition` | Optional condition statement/expression where this expression is used|
 | `parentExpression` | `FASTTExpression` | `expression` | `FASTTUnaryExpression` | Parent (unary) expression|
 | `parentExpressionLeft` | `FASTTExpression` | `leftOperand` | `FASTTBinaryExpression` | Parent (binary) expression of which I am left side|
 | `parentExpressionRight` | `FASTTExpression` | `rightOperand` | `FASTTBinaryExpression` | Parent (binary) expression of which I am right side|

--- a/src/FAST-Core-Model/FASTTNumericalLiteral.trait.st
+++ b/src/FAST-Core-Model/FASTTNumericalLiteral.trait.st
@@ -10,7 +10,7 @@ A numerical literal
 | `argumentOwner` | `FASTTExpression` | `arguments` | `FASTTWithArguments` | my owner|
 | `assignedIn` | `FASTTExpression` | `expression` | `FASTTAssignment` | Optional assignment where this expression is used|
 | `expressionStatementOwner` | `FASTTExpression` | `expression` | `FASTTExpressionStatement` | The expression statement that own me (if it's the case|
-| `parentConditionalStatement` | `FASTTExpression` | `condition` | `FASTTConditionalStatement` | Optional condition statement where this expression is used|
+| `parentConditional` | `FASTTExpression` | `condition` | `FASTTWithCondition` | Optional condition statement/expression where this expression is used|
 | `parentExpression` | `FASTTExpression` | `expression` | `FASTTUnaryExpression` | Parent (unary) expression|
 | `parentExpressionLeft` | `FASTTExpression` | `leftOperand` | `FASTTBinaryExpression` | Parent (binary) expression of which I am left side|
 | `parentExpressionRight` | `FASTTExpression` | `rightOperand` | `FASTTBinaryExpression` | Parent (binary) expression of which I am right side|

--- a/src/FAST-Core-Model/FASTTStringLiteral.trait.st
+++ b/src/FAST-Core-Model/FASTTStringLiteral.trait.st
@@ -10,7 +10,7 @@ A string literal
 | `argumentOwner` | `FASTTExpression` | `arguments` | `FASTTWithArguments` | my owner|
 | `assignedIn` | `FASTTExpression` | `expression` | `FASTTAssignment` | Optional assignment where this expression is used|
 | `expressionStatementOwner` | `FASTTExpression` | `expression` | `FASTTExpressionStatement` | The expression statement that own me (if it's the case|
-| `parentConditionalStatement` | `FASTTExpression` | `condition` | `FASTTConditionalStatement` | Optional condition statement where this expression is used|
+| `parentConditional` | `FASTTExpression` | `condition` | `FASTTWithCondition` | Optional condition statement/expression where this expression is used|
 | `parentExpression` | `FASTTExpression` | `expression` | `FASTTUnaryExpression` | Parent (unary) expression|
 | `parentExpressionLeft` | `FASTTExpression` | `leftOperand` | `FASTTBinaryExpression` | Parent (binary) expression of which I am left side|
 | `parentExpressionRight` | `FASTTExpression` | `rightOperand` | `FASTTBinaryExpression` | Parent (binary) expression of which I am right side|

--- a/src/FAST-Core-Model/FASTTUnaryExpression.trait.st
+++ b/src/FAST-Core-Model/FASTTUnaryExpression.trait.st
@@ -10,7 +10,7 @@ A trait representing an unary expression of a node of a source code.
 | `argumentOwner` | `FASTTExpression` | `arguments` | `FASTTWithArguments` | my owner|
 | `assignedIn` | `FASTTExpression` | `expression` | `FASTTAssignment` | Optional assignment where this expression is used|
 | `expressionStatementOwner` | `FASTTExpression` | `expression` | `FASTTExpressionStatement` | The expression statement that own me (if it's the case|
-| `parentConditionalStatement` | `FASTTExpression` | `condition` | `FASTTConditionalStatement` | Optional condition statement where this expression is used|
+| `parentConditional` | `FASTTExpression` | `condition` | `FASTTWithCondition` | Optional condition statement/expression where this expression is used|
 | `parentExpression` | `FASTTExpression` | `expression` | `FASTTUnaryExpression` | Parent (unary) expression|
 | `parentExpressionLeft` | `FASTTExpression` | `leftOperand` | `FASTTBinaryExpression` | Parent (binary) expression of which I am left side|
 | `parentExpressionRight` | `FASTTExpression` | `rightOperand` | `FASTTBinaryExpression` | Parent (binary) expression of which I am right side|

--- a/src/FAST-Core-Model/FASTTVariableExpression.trait.st
+++ b/src/FAST-Core-Model/FASTTVariableExpression.trait.st
@@ -11,7 +11,7 @@ A node that wraps around structural entity
 | `assignedIn` | `FASTTExpression` | `expression` | `FASTTAssignment` | Optional assignment where this expression is used|
 | `expressionStatementOwner` | `FASTTExpression` | `expression` | `FASTTExpressionStatement` | The expression statement that own me (if it's the case|
 | `invokedIn` | `FASTTNamedEntity` | `invoked` | `FASTTInvocation` | Optional invocation where this name is used|
-| `parentConditionalStatement` | `FASTTExpression` | `condition` | `FASTTConditionalStatement` | Optional condition statement where this expression is used|
+| `parentConditional` | `FASTTExpression` | `condition` | `FASTTWithCondition` | Optional condition statement/expression where this expression is used|
 | `parentExpression` | `FASTTExpression` | `expression` | `FASTTUnaryExpression` | Parent (unary) expression|
 | `parentExpressionLeft` | `FASTTExpression` | `leftOperand` | `FASTTBinaryExpression` | Parent (binary) expression of which I am left side|
 | `parentExpressionRight` | `FASTTExpression` | `rightOperand` | `FASTTBinaryExpression` | Parent (binary) expression of which I am right side|

--- a/src/FAST-Core-Model/FASTTWithCondition.trait.st
+++ b/src/FAST-Core-Model/FASTTWithCondition.trait.st
@@ -1,0 +1,53 @@
+"
+## Relations
+======================
+
+### Children
+| Relation | Origin | Opposite | Type | Comment |
+|---|
+| `condition` | `FASTTWithCondition` | `parentConditional` | `FASTTExpression` | The boolean condition tested|
+
+
+
+"
+Trait {
+	#name : 'FASTTWithCondition',
+	#instVars : [
+		'#condition => FMOne type: #FASTTExpression opposite: #parentConditional'
+	],
+	#category : 'FAST-Core-Model-Traits',
+	#package : 'FAST-Core-Model',
+	#tag : 'Traits'
+}
+
+{ #category : 'meta' }
+FASTTWithCondition classSide >> annotation [
+
+	<FMClass: #TWithCondition super: #Object>
+	<package: #'FAST-Core-Model'>
+	<generated>
+	^ self
+]
+
+{ #category : 'accessing' }
+FASTTWithCondition >> condition [
+	"Relation named: #condition type: #FASTTExpression opposite: #parentConditional"
+
+	<generated>
+	<FMComment: 'The boolean condition tested'>
+	^ condition
+]
+
+{ #category : 'accessing' }
+FASTTWithCondition >> condition: anObject [
+
+	<generated>
+	condition := anObject
+]
+
+{ #category : 'navigation' }
+FASTTWithCondition >> conditionGroup [
+	<generated>
+	<navigation: 'Condition'>
+	^ MooseSpecializedGroup with: self condition
+]

--- a/src/FAST-Model-Generator/FASTMetamodelGenerator.class.st
+++ b/src/FAST-Model-Generator/FASTMetamodelGenerator.class.st
@@ -36,7 +36,8 @@ Class {
 		'tUnaryExpression',
 		'tConditionalStatement',
 		'tLoopStatement',
-		'tWithStatements'
+		'tWithStatements',
+		'tWithCondition'
 	],
 	#category : 'FAST-Model-Generator',
 	#package : 'FAST-Model-Generator'
@@ -226,6 +227,7 @@ FASTMetamodelGenerator >> defineHierarchy [
 
 	tStatement --|> tEntity.
 	tConditionalStatement --|> tStatement.
+	tConditionalStatement --|> tWithCondition.
 	tExpressionStatement --|> tStatement.
 	tLoopStatement --|> tStatement.
 	tNamedBehaviouralEntity --|> tBehaviouralEntity.
@@ -288,8 +290,8 @@ FASTMetamodelGenerator >> defineRelations [
 	((tComment property: #container) comment: 'Source code entity containing the comment')
 	*-<> ((tWithComments property: #comments) comment: 'list of comments defined in the entity').
 
-	((tConditionalStatement property: #condition) comment: 'The boolean condition tested')
-	<>- ((tExpression property: #parentConditionalStatement) comment: 'Optional condition statement where this expression is used').
+	((tWithCondition property: #condition) comment: 'The boolean condition tested')
+	<>- ((tExpression property: #parentConditional) comment: 'Optional condition statement/expression where this expression is used').
 
 	((tExpressionStatement property: #expression) comment: 'The expression of the statement')
 	<>- ((tExpression property: #expressionStatementOwner) comment: 'The expression statement that own me (if it''s the case').
@@ -369,6 +371,7 @@ FASTMetamodelGenerator >> defineTraits [
 	tWithArguments := builder newTraitNamed: #TWithArguments comment: 'I have arguments'. 
 	tWithComments := builder newTraitNamed: #TWithComments.
 	tWithComments comment: self commentForTWithComments.
+	tWithCondition := builder newTraitNamed: #TWithCondition.
 	tWithParameters := builder newTraitNamed: #TWithParameters comment: 'I have parameters'.
 	tWithStatements := builder newTraitNamed: #TWithStatements.
 ]


### PR DESCRIPTION
Because currently we have FASTTConditionalStatement but not everything with conditions are statements. For example conditional expressions in Java or Python are not statements but have conditions.