### PR TITLE
Make CFG sourceCode not depend on an exporter that does not exist by …

### DIFF
--- a/src/FAST-Core-Tools/FASTAbstractBasicBlock.class.st
+++ b/src/FAST-Core-Tools/FASTAbstractBasicBlock.class.st
@@ -59,8 +59,7 @@ FASTAbstractBasicBlock >> isEmpty [
 FASTAbstractBasicBlock >> isFinal [
 	"The block last statement is also the last executed one in the CFG"
 
-	^(self nextBlocks isEmpty) or:
-	[ self nextBlocks anySatisfy: [ :block | block isNil or: [ block isNullBlock]] ]
+	^ self nextBlocks isEmpty or: [ self nextBlocks anySatisfy: [ :block | block isNil or: [ block isNullBlock ] ] ]
 ]
 
 { #category : 'testing' }
@@ -96,7 +95,9 @@ FASTAbstractBasicBlock >> nextBlocks [
 { #category : 'printing' }
 FASTAbstractBasicBlock >> sourceCode [
 
-	self subclassResponsibility 
+	self statements ifEmpty: [ ^ '' ].
+
+	^ self firstStatement sourceText copyFrom: self firstStatement startPos to: self lastStatement endPos
 ]
 
 { #category : 'accessing' }

--- a/src/FAST-Core-Tools/FASTBasicBlock.class.st
+++ b/src/FAST-Core-Tools/FASTBasicBlock.class.st
@@ -42,18 +42,3 @@ FASTBasicBlock >> nextBlocks [
 		ifNil: [ #() ]
 		ifNotNil: [ { nextBlock } ]
 ]
-
-{ #category : 'printing' }
-FASTBasicBlock >> sourceCode [
-
-	| exporter |
-	exporter := self firstStatement exporterForCFG.
-	^ String streamContents: [ :s | 
-		  self statements do: [ :stmt |
-			  s nextPutAll: (exporter export: stmt) ] ]
-	
-	"^ self firstStatement exporterForCFG export:
-	  (self firstStatement newStatementBlockForCFG
-		   statements: self statements;
-		   yourself)"
-]

--- a/src/FAST-Core-Tools/FASTConditionalBasicBlock.class.st
+++ b/src/FAST-Core-Tools/FASTConditionalBasicBlock.class.st
@@ -79,12 +79,6 @@ FASTConditionalBasicBlock >> nextBlocks [
 ]
 
 { #category : 'printing' }
-FASTConditionalBasicBlock >> sourceCode [
-
-	^self firstStatement exportForCFG
-]
-
-{ #category : 'printing' }
 FASTConditionalBasicBlock >> statement: aFASTFortranStatement [
 
 	self addStatement: aFASTFortranStatement 

--- a/src/FAST-Core-Tools/FASTNullBlock.class.st
+++ b/src/FAST-Core-Tools/FASTNullBlock.class.st
@@ -34,9 +34,3 @@ FASTNullBlock >> nextBlocks [
 
 	^#()
 ]
-
-{ #category : 'testing' }
-FASTNullBlock >> sourceCode [
-
-	^''
-]

--- a/src/FAST-Core-Tools/FASTTryBasicBlock.class.st
+++ b/src/FAST-Core-Tools/FASTTryBasicBlock.class.st
@@ -11,13 +11,3 @@ FASTTryBasicBlock >> addStatement: aFASTStatement [
 
 	self statements add: aFASTStatement
 ]
-
-{ #category : 'printing' }
-FASTTryBasicBlock >> sourceCode [
-
-	| exporter |
-	exporter := self firstStatement exporterForCFG.
-	^ String streamContents: [ :s |
-		  self statements do: [ :stmt |
-			  s nextPutAll: (exporter export: stmt) ] ]
-]


### PR DESCRIPTION
…default in FAST

The method #sourceCode depends on a source code exporter that does not exist in FAST. I porpose a new implementation that does not depend on it. Maybe in the futur we should add an alternative version with the exporter, but for now only Fortran has one.