### PR TITLE
CFG: Support for fall-through switches

### DIFF
--- a/src/FAST-Core-Tools/FASTCFGAbstractMultipleConditionBlock.class.st
+++ b/src/FAST-Core-Tools/FASTCFGAbstractMultipleConditionBlock.class.st
@@ -52,6 +52,16 @@ FASTCFGAbstractMultipleConditionBlock >> initialize [
 	blocksMap := OrderedDictionary new
 ]
 
+{ #category : 'testing' }
+FASTCFGAbstractMultipleConditionBlock >> isFull [
+	"I am full when I have a branch pointing at what happens if no specific condition (exception or case) is met and this branch has a nil pattern."
+
+	^ blocksMap
+		  at: nil
+		  ifPresent: [ :value | value isNotNil ]
+		  ifAbsent: [ false ]
+]
+
 { #category : 'accessing' }
 FASTCFGAbstractMultipleConditionBlock >> nextBlockForValues [
 

--- a/src/FAST-Core-Tools/FASTCFGFallThroughSwitchContextEntry.class.st
+++ b/src/FAST-Core-Tools/FASTCFGFallThroughSwitchContextEntry.class.st
@@ -1,0 +1,25 @@
+"
+I am a context entry used to represent fall-through switches (switches where you need to add a break at the end of a case if you do not want to execute the code from the cases that follow the one validated by the input).
+"
+Class {
+	#name : 'FASTCFGFallThroughSwitchContextEntry',
+	#superclass : 'FASTCFGContextEntry',
+	#instVars : [
+		'fallThroughCase'
+	],
+	#category : 'FAST-Core-Tools-CFG',
+	#package : 'FAST-Core-Tools',
+	#tag : 'CFG'
+}
+
+{ #category : 'adding' }
+FASTCFGFallThroughSwitchContextEntry >> addNextBlock: aBlock [ 
+
+	"If my last case had no break, i also add the new block to it."
+	fallThroughCase ifNotNil: [ fallThroughCase addNextBlock: aBlock ].
+	self conditional addNextBlock: aBlock.
+	
+	"I reset the fall-through case if needed, and check if this new case ends with a break or not."
+	fallThroughCase := nil.
+	aBlock statements last isBreakStatement ifFalse: [ fallThroughCase := aBlock ]
+]

--- a/src/FAST-Core-Tools/FASTCFGSwitchBlock.class.st
+++ b/src/FAST-Core-Tools/FASTCFGSwitchBlock.class.st
@@ -8,13 +8,23 @@ Then I associate the statement defining the case to the block executed if we sel
 Class {
 	#name : 'FASTCFGSwitchBlock',
 	#superclass : 'FASTCFGAbstractMultipleConditionBlock',
-	#instVars : [
-		'isFull'
-	],
 	#category : 'FAST-Core-Tools-CFG',
 	#package : 'FAST-Core-Tools',
 	#tag : 'CFG'
 }
+
+{ #category : 'adding' }
+FASTCFGSwitchBlock >> addNextBlock: aBlock [
+	"I either have the normal addNextBlock behaviour or I add the path where no case was validated during execution, and there is no default case."
+
+	| lastAssociation |
+	lastAssociation := blocksMap associations last.
+	lastAssociation value ifNil: [ ^ super addNextBlock: aBlock ].
+
+	self assert: (blocksMap includesKey: nil) not description: 'I should have no default case.'.
+
+	^ blocksMap at: nil put: aBlock
+]
 
 { #category : 'accessing' }
 FASTCFGSwitchBlock >> defaultCase [
@@ -26,25 +36,6 @@ FASTCFGSwitchBlock >> defaultCase [
 FASTCFGSwitchBlock >> includesPattern: aPattern [
 
 	^ self patterns anySatisfy: [ :pattern | pattern isSameAsCFGCasePattern: aPattern ]
-]
-
-{ #category : 'initialization' }
-FASTCFGSwitchBlock >> initialize [
-
-	super initialize.
-	isFull := false
-]
-
-{ #category : 'accessing' }
-FASTCFGSwitchBlock >> isFull [
-	"In the case of a switch, we cannot know with just the node so the algo will tell us when it is full at the closing of the switch.."
-
-	^ isFull
-]
-
-{ #category : 'accessing' }
-FASTCFGSwitchBlock >> isFull: anObject [
-	isFull := anObject
 ]
 
 { #category : 'testing' }

--- a/src/FAST-Core-Tools/FASTCFGTryBlock.class.st
+++ b/src/FAST-Core-Tools/FASTCFGTryBlock.class.st
@@ -16,16 +16,6 @@ Class {
 }
 
 { #category : 'testing' }
-FASTCFGTryBlock >> isFull [
-	"I am full when I have a branch pointing what happens if there is no exception caught and this branch has a nil pattern."
-
-	^ blocksMap
-		  at: nil
-		  ifPresent: [ :value | value isNotNil ]
-		  ifAbsent: [ false ]
-]
-
-{ #category : 'testing' }
 FASTCFGTryBlock >> isTry [
 
 	^ true

--- a/src/FAST-Core-Tools/FASTTCFGUtility.trait.st
+++ b/src/FAST-Core-Tools/FASTTCFGUtility.trait.st
@@ -52,17 +52,36 @@ FASTTCFGUtility >> buildAndPushBlockOfType: aClass [
 	
 	Ideally I should only be used by FASTTCFGUtility>>#buildAndUse:during: so that the context get poped when needed. But in some cases it get useful for me to be used alone. For example, when implementing the CFG of an elif since the false branch of the elif is the next elif or else of the parent if, and not a child of the elif."
 
+	^ self buildAndPushBlockOfType: aClass usingContextClass: FASTCFGContextEntry
+]
+
+{ #category : 'running' }
+FASTTCFGUtility >> buildAndPushBlockOfType: aClass usingContextClass: aContextClass [
+	"I create a new block provided in parameter. It should be a conditional node.
+	I also need a context class to appropriately chain the blocks that will be generated as I process this conditional FAST node.
+	
+	Ideally I should only be used by FASTTCFGUtility>>#buildAndUse:during: so that the context get poped when needed. But in some cases it get useful for me to be used alone. For example, when implementing the CFG of an elif since the false branch of the elif is the next elif or else of the parent if, and not a child of the elif."
+
 	| block |
 	block := self buildBlockOfType: aClass.
-	context push: (FASTCFGContextEntry conditional: block).
+	context push: (aContextClass conditional: block).
 	^ block
 ]
 
 { #category : 'running' }
 FASTTCFGUtility >> buildAndUse: aClass during: aBlock [
 
+	^ self
+		  buildAndUse: aClass
+		  usingContextClass: FASTCFGContextEntry
+		  during: aBlock
+]
+
+{ #category : 'running' }
+FASTTCFGUtility >> buildAndUse: aClass usingContextClass: aContextClass during: aBlock [
+
 	| conditional |
-	conditional := self buildAndPushBlockOfType: aClass.
+	conditional := self buildAndPushBlockOfType: aClass usingContextClass: aContextClass.
 
 	aBlock cull: conditional.
 	

--- a/src/FAST-Core-Tools/FASTTCFGUtility.trait.st
+++ b/src/FAST-Core-Tools/FASTTCFGUtility.trait.st
@@ -101,6 +101,16 @@ FASTTCFGUtility >> buildAndUseConditionalDuring: aBlock [
 ]
 
 { #category : 'running' }
+FASTTCFGUtility >> buildAndUseFallThroughSwitchDuring: aBlock [
+
+	^ self
+		  buildAndUse: FASTCFGSwitchBlock
+		  usingContextClass: FASTCFGFallThroughSwitchContextEntry
+		  during: [ :switch |
+				  aBlock cull: switch ]
+]
+
+{ #category : 'running' }
 FASTTCFGUtility >> buildAndUseLoopDuring: aBlock [
 	"For loops, we do an extra step compared to conditionals in order to build the loops if needed."
 
@@ -115,8 +125,7 @@ FASTTCFGUtility >> buildAndUseLoopDuring: aBlock [
 FASTTCFGUtility >> buildAndUseSwitchDuring: aBlock [
 
 	^ self buildAndUse: FASTCFGSwitchBlock during: [ :switch |
-			  aBlock cull: switch.
-			  switch isFull: true ]
+			  aBlock cull: switch ]
 ]
 
 { #category : 'running' }


### PR DESCRIPTION
This PR contains:
- Refactorings to be able to use builder methods with a chosen context class. The original methods now call those new methods and pass the `FASTCFGContextEntry` class as parameter.
- Refactorings on the `isFull` attributes of multiple conditional nodes. Switches are now considered full identically to try blocks, if they have a nil branch pointing to a node (which is either a default node, or the block representing the instructions after the switch).
- Support for fall-through switches using a specific context class `FASTCFGFallThroughSwitchContextEntry` and a builder method `buildAndUseFallThroughSwitchDuring:`