### PR TITLE
Apply `children` -> `containedEntities` deprecation

### DIFF
--- a/src/FAST-Core-Tools-Tests/FamixModelComparatorTest.class.st
+++ b/src/FAST-Core-Tools-Tests/FamixModelComparatorTest.class.st
@@ -4,9 +4,8 @@ Class {
 	#instVars : [
 		'validator'
 	],
-	#category : 'FAST-Core-Tools-Validator',
-	#package : 'FAST-Core-Tools',
-	#tag : 'Validator'
+	#category : 'FAST-Core-Tools-Tests',
+	#package : 'FAST-Core-Tools-Tests'
 }
 
 { #category : 'running' }

--- a/src/FAST-Core-Tools/FamixModelComparator.class.st
+++ b/src/FAST-Core-Tools/FamixModelComparator.class.st
@@ -53,9 +53,7 @@ FamixModelComparator >> beStrict [
 { #category : 'utilities' }
 FamixModelComparator >> childrenNodes: astNode [
 
-	^OrderedCollection withAll:
-		(astNode children sorted: [:a :b | a startPos <= b startPos])
-
+	^ OrderedCollection withAll: (astNode containedEntities sorted: [ :a :b | a startPos <= b startPos ])
 ]
 
 { #category : 'comparison' }


### PR DESCRIPTION
I also wanted to apply `mooseDescription` -> `metadescription` but that's not compatible with Moose 12.

Plus move test class to test package.