### PR TITLE
fix(Moose12 Compatibility): `containers` -> `ancestors`

### DIFF
--- a/src/BaselineOfFAST/BaselineOfFAST.class.st
+++ b/src/BaselineOfFAST/BaselineOfFAST.class.st
@@ -69,7 +69,7 @@ BaselineOfFAST >> definePackages: spec [
 
 { #category : 'baselines' }
 BaselineOfFAST >> ensureMoose12Compatibility [
-	"FAST v3 works on Moose 12 and Moose 13. Since we are using some methods of Moose 13, I ensure we have everything needed. Delete me once Moose 12 support will be dropped."
+	"FAST v3 works on Moose 12 and Moose 13. Since we are using some methods of Moose 13, I ensure we have everything needed. Delete me once Moose 12 support will be dropped."
 
 	| class |
 	class := self class environment at: #TEntityMetaLevelDependency.
@@ -79,7 +79,7 @@ BaselineOfFAST >> ensureMoose12Compatibility [
 			{ 'containersOfType: aType
 	"I am used to return all the first encountered entities at a given famix class scope that are up in the containment tree of the metamodel"
 
-	^ self query containers ofType: aType'. 'containedEntities
+	^ self query ancestors ofType: aType'. 'containedEntities
 
 	^ self children'. 'allContainedEntities
 


### PR DESCRIPTION
`containersOfType:` is compiled as a compatibility shim for Moose 12, but it used `containers` instead of the old `ancestors` so it wasn't compatible with Moose 12.