### PR TITLE
Break cycles in loop blocks of CFG during a CFG visit

### DIFF
--- a/src/FAST-Core-Model-Extension/FASTTEntity.extension.st
+++ b/src/FAST-Core-Model-Extension/FASTTEntity.extension.st
@@ -68,8 +68,7 @@ FASTTEntity >> inspectionFASTSourceCode: aBuilder [
 
 	<inspectorPresentationOrder: 1.2 title: 'FASTSourceCode'>
 	| hasSource sourceText |
-	(hasSource := self sourceText isNotEmpty and: [
-		              self startPos isNotNil and: [ self endPos isNotNil ] ])
+	(hasSource := self sourceText isNotEmpty and: [ self startPos isNotNil and: [ self endPos isNotNil ] ])
 		ifFalse: [ "try to export source code"
 				self asSourceCode
 					ifNil: [
@@ -77,16 +76,21 @@ FASTTEntity >> inspectionFASTSourceCode: aBuilder [
 								  text: 'Not available';
 								  yourself ]
 					ifNotNil: [ :code | sourceText := Text fromString: code ] ]
-		ifTrue: [
-				sourceText := self mooseModel fastHighligther new highlight:
-					              self rootNode ].
-	^ aBuilder newMorph morph: (RubScrolledTextMorph new
-			   setText: sourceText;
-			   in: [ :this |
-					   this textArea readOnly: true.
-					   hasSource ifTrue: [
-							   this selectionInterval: (self startPos to: self endPos) ] ];
-			   yourself)
+		ifTrue: [ sourceText := self mooseModel fastHighligther new highlight: self rootNode ].
+
+	^ aBuilder newCode
+		  withoutSyntaxHighlight;
+		  withLineNumbers;
+		  text: sourceText;
+		  beNotEditable;
+		  in: [ :this |
+				  hasSource ifTrue: [
+							  this
+								  addTextSegmentDecoration: (SpTextPresenterDecorator forHighlight
+										   interval: (self startPos to: self endPos + 1);
+										   yourself);
+								  selectionInterval: (self startPos to: self endPos + 1) ] ];
+		  yourself
 ]
 
 { #category : '*FAST-Core-Model-Extension' }

--- a/src/FAST-Core-Tools/FASTCFGTVisitor.trait.st
+++ b/src/FAST-Core-Tools/FASTCFGTVisitor.trait.st
@@ -25,7 +25,7 @@ FASTCFGTVisitor >> visit: aCFGBlockOrFASTEntity [
 FASTCFGTVisitor >> visitCFGAbstractBlock: aBlock [
 	"Any block visit their statements and next block if this was not done already (this can happen with loop blocks)."
 
-	self visitedBlocks add: self.
+	self visitedBlocks add: aBlock.
 
 	aBlock statements do: [ :statement | statement accept: self ].
 	aBlock nextBlocks do: [ :block | (self visitedBlocks includes: block) ifFalse: [ block accept: self ] ]

--- a/src/FAST-Core-Tools/FASTCFGTVisitor.trait.st
+++ b/src/FAST-Core-Tools/FASTCFGTVisitor.trait.st
@@ -2,9 +2,14 @@
 I am a trait to introduce the capability to visit a Control Flow Graph. 
 
 The visitor using me also need to use a visitor for the language of the CFG. For example, for Python, the visitor will need to use me and FASTTPythonVisitor. 
+
+In case of loops, I'll visit the next blocks only once.
 "
 Trait {
 	#name : 'FASTCFGTVisitor',
+	#instVars : [
+		'visitedBlocks'
+	],
 	#category : 'FAST-Core-Tools-CFG',
 	#package : 'FAST-Core-Tools',
 	#tag : 'CFG'
@@ -18,10 +23,12 @@ FASTCFGTVisitor >> visit: aCFGBlockOrFASTEntity [
 
 { #category : 'visiting' }
 FASTCFGTVisitor >> visitCFGAbstractBlock: aBlock [
-	"Any block visit their statements."
+	"Any block visit their statements and next block if this was not done already (this can happen with loop blocks)."
+
+	self visitedBlocks add: self.
 
 	aBlock statements do: [ :statement | statement accept: self ].
-	aBlock nextBlocks do: [ :bloc | bloc accept: self ]
+	aBlock nextBlocks do: [ :block | (self visitedBlocks includes: block) ifFalse: [ block accept: self ] ]
 ]
 
 { #category : 'visiting' }
@@ -69,4 +76,10 @@ FASTCFGTVisitor >> visitCFGSwitchBlock: aBlock [
 FASTCFGTVisitor >> visitCFGTryBlock: aBlock [
 
 	self visitCFGAbstractMultipleConditionalBlock: aBlock
+]
+
+{ #category : 'accessing' }
+FASTCFGTVisitor >> visitedBlocks [
+
+	^ visitedBlocks ifNil: [ visitedBlocks := IdentitySet new ]
 ]


### PR DESCRIPTION
And improve the source code inspection to not rely on morphic and add line numbers (I'm working on large files and this helps)