### PR TITLE
Add the management of merge blocks in CFG conditional blocks

### DIFF
--- a/src/FAST-Core-Tools/FASTCFGAbstractBlock.class.st
+++ b/src/FAST-Core-Tools/FASTCFGAbstractBlock.class.st
@@ -61,6 +61,12 @@ FASTCFGAbstractBlock >> allFollowingBlocks [
 	^ self deep: #nextBlocks collect: #yourself
 ]
 
+{ #category : 'accessing' }
+FASTCFGAbstractBlock >> allPreviousBlocks [
+
+	^ self deep: #previousBlocks collect: #yourself
+]
+
 { #category : 'mermaid' }
 FASTCFGAbstractBlock >> asMermaidScript [
 	"I genrerate a mermaid script to display the flowchart"

--- a/src/FAST-Core-Tools/FASTCFGAbstractConditionalBlock.class.st
+++ b/src/FAST-Core-Tools/FASTCFGAbstractConditionalBlock.class.st
@@ -2,10 +2,15 @@
 I am an abstract class to represent conditional blocks. 
 
 A conditional block is a block that will have multiple next blocks and not only one. In general the last statement of the block is the condition that triggered the split.
+
+A conditional also knows its merge block. The merge block is the first block present in all branches of the conditional. This means that it is the first block right after the conditional block
 "
 Class {
 	#name : 'FASTCFGAbstractConditionalBlock',
 	#superclass : 'FASTCFGAbstractBlock',
+	#instVars : [
+		'mergeBlock'
+	],
 	#category : 'FAST-Core-Tools-CFG',
 	#package : 'FAST-Core-Tools',
 	#tag : 'CFG'
@@ -35,6 +40,16 @@ FASTCFGAbstractConditionalBlock >> endsWithContinueStatement [
 FASTCFGAbstractConditionalBlock >> isConditional [
 
 	^ true
+]
+
+{ #category : 'accessing' }
+FASTCFGAbstractConditionalBlock >> mergeBlock [
+	^ mergeBlock
+]
+
+{ #category : 'accessing' }
+FASTCFGAbstractConditionalBlock >> mergeBlock: anObject [
+	mergeBlock := anObject
 ]
 
 { #category : 'printing' }

--- a/src/FAST-Core-Tools/FASTCFGAbstractMultipleConditionBlock.class.st
+++ b/src/FAST-Core-Tools/FASTCFGAbstractMultipleConditionBlock.class.st
@@ -35,6 +35,7 @@ FASTCFGAbstractMultipleConditionBlock >> addNextBlock: aBlock [
 	lastAssociation := blocksMap associations last.
 	self assert: lastAssociation value isNil description: 'My last pattern should be associated to nil since it should not have a value yet.'.
 
+	aBlock addPreviousBlock: self.
 	^ blocksMap at: lastAssociation key put: aBlock
 ]
 

--- a/src/FAST-Core-Tools/FASTTCFGUtility.trait.st
+++ b/src/FAST-Core-Tools/FASTTCFGUtility.trait.st
@@ -27,7 +27,8 @@ Trait {
 	#instVars : [
 		'startBlock',
 		'currentStatements',
-		'context'
+		'context',
+		'conditionalsToMerge'
 	],
 	#category : 'FAST-Core-Tools-CFG',
 	#package : 'FAST-Core-Tools',
@@ -65,13 +66,14 @@ FASTTCFGUtility >> buildAndUse: aClass during: aBlock [
 	conditional := self buildAndPushBlockOfType: aClass.
 
 	aBlock cull: conditional.
-	
+
 	"Sometimes it is possible that we will need to pop multiple conditionals. 
 	For example, in the case of elif. Usually the elif contains the `then` block but not the `else`. The else will be either the next elif, or next else or next block after the if.
 	In that case, #buildNewConditional allows to push conditional blocks that I will clause with the containing conditional here. "
 	[ conditional == self currentConditional ] whileFalse: [ context pop ].
 
 	context pop.
+	conditionalsToMerge add: conditional. "We mark this conditional block as ready to get its merge block when we will create the next block."
 	^ conditional
 ]
 
@@ -185,11 +187,22 @@ FASTTCFGUtility >> finializeLoop [
 		thenDo: [ :block | block addNextBlock: self currentConditional ]
 ]
 
+{ #category : 'running' }
+FASTTCFGUtility >> handlePossibleMergPointsTo: newBlock [
+	"If we have conditional blocks that do not have their merge block yet and that are present in the previous blocks of the new block, we set the new block is the merge block of the conditional."
+
+	conditionalsToMerge reverseDo: [ :conditional |
+			(newBlock allPreviousBlocks includes: conditional) ifTrue: [
+					conditional mergeBlock: newBlock.
+					conditionalsToMerge remove: conditional ] ]
+]
+
 { #category : 'initialization' }
 FASTTCFGUtility >> initializeCFG [
 
 	context := Stack new.
-	currentStatements := OrderedCollection new
+	currentStatements := OrderedCollection new.
+	conditionalsToMerge := OrderedCollection new
 ]
 
 { #category : 'running' }
@@ -201,10 +214,12 @@ FASTTCFGUtility >> managePreviousBlocksOf: newBlock [
 			newBlock isStart: true.
 			^ self ].
 
-	context top currentBlocks ifEmpty: [  context top addNextBlock: newBlock ] ifNotEmpty: [ :blocksAtScope |
+	context top currentBlocks ifEmpty: [ context top addNextBlock: newBlock ] ifNotEmpty: [ :blocksAtScope |
 			(blocksAtScope flatCollectAsSet: #withAllFollowingBlocks)
 				reject: [ :block | block isFull or: [ block shouldBreakOrContinueInContext: context ] ]
-				thenDo: [ :block | block addNextBlock: newBlock ] ]
+				thenDo: [ :block |
+						block addNextBlock: newBlock.
+						self handlePossibleMergPointsTo: newBlock ] ]
 ]
 
 { #category : 'asserting' }


### PR DESCRIPTION
I'll use this next to update the CFG visitor and visit all blocks of a conditional before visiting the blocks after it