### PR TITLE
Improve cfg visitor

### DIFF
--- a/src/FAST-Core-Tools/FASTCFGTVisitor.trait.st
+++ b/src/FAST-Core-Tools/FASTCFGTVisitor.trait.st
@@ -91,7 +91,9 @@ FASTCFGTVisitor >> visitCFGAbstractMultipleConditionalBlock: aBlock [
 	aBlock patterns do: [ :pattern |
 			pattern isCollection
 				ifTrue: [ pattern do: [ :statement | statement accept: self ] ]
-				ifFalse: [ pattern accept: self ] ].
+				ifFalse: [ 
+				"We do a nil check because if we have a default case, the pattern will be nil"
+				pattern ifNotNil: [ self visit: pattern ] ] ].
 
 	self visitCFGAbstractConditionalBlock: aBlock
 ]

--- a/src/FAST-Core-Tools/FASTCFGTVisitor.trait.st
+++ b/src/FAST-Core-Tools/FASTCFGTVisitor.trait.st
@@ -18,6 +18,7 @@ Trait {
 { #category : 'visiting' }
 FASTCFGTVisitor >> visit: aCFGBlockOrFASTEntity [
 
+	(self visitedBlocks includes: aCFGBlockOrFASTEntity) ifTrue: [ ^ self ]. "Breaking the visit if it was already visited"
 	^ aCFGBlockOrFASTEntity ifNotNil: [ aCFGBlockOrFASTEntity accept: self ]
 ]
 
@@ -26,15 +27,16 @@ FASTCFGTVisitor >> visitCFGAbstractBlock: aBlock [
 	"Any block visit their statements and next block if this was not done already (this can happen with loop blocks)."
 
 	self visitedBlocks add: aBlock.
-
-	aBlock statements do: [ :statement | statement accept: self ].
-	aBlock nextBlocks do: [ :block | (self visitedBlocks includes: block) ifFalse: [ block accept: self ] ]
+	aBlock statements do: [ :statement | statement accept: self ]
 ]
 
 { #category : 'visiting' }
 FASTCFGTVisitor >> visitCFGAbstractConditionalBlock: aBlock [
 
-	self visitCFGAbstractBlock: aBlock
+	self visitCFGAbstractBlock: aBlock.
+
+	self flag: #todo. "We should change the order of the visit to visit all the blocks of the conditional before the ones after the conditional."
+	aBlock nextBlocks do: [ :block | self visit: block ]
 ]
 
 { #category : 'visiting' }
@@ -51,7 +53,9 @@ FASTCFGTVisitor >> visitCFGAbstractMultipleConditionalBlock: aBlock [
 { #category : 'visiting' }
 FASTCFGTVisitor >> visitCFGBlock: aBlock [
 
-	self visitCFGAbstractBlock: aBlock
+	self visitCFGAbstractBlock: aBlock.
+
+	self visit: aBlock nextBlock
 ]
 
 { #category : 'visiting' }

--- a/src/FAST-Core-Tools/FASTCFGTVisitor.trait.st
+++ b/src/FAST-Core-Tools/FASTCFGTVisitor.trait.st
@@ -8,17 +8,53 @@ In case of loops, I'll visit the next blocks only once.
 Trait {
 	#name : 'FASTCFGTVisitor',
 	#instVars : [
-		'visitedBlocks'
+		'visitedBlocks',
+		'stoppingBlocks'
 	],
 	#category : 'FAST-Core-Tools-CFG',
 	#package : 'FAST-Core-Tools',
 	#tag : 'CFG'
 }
 
+{ #category : 'hooks' }
+FASTCFGTVisitor >> postConditonalsBranchVisitOf: firstBranchBlock conditional: aConditionalBlock [
+	"No-op - hook"
+
+	
+]
+
+{ #category : 'hooks' }
+FASTCFGTVisitor >> postConditonalsBranchesVisitOf: aConditionalBlock [
+	"No-op - hook"
+
+	
+]
+
+{ #category : 'hooks' }
+FASTCFGTVisitor >> preConditonalsBranchVisitOf: firstBranchBlock conditional: aConditionalBlock [
+	"No-op - hook"
+
+	
+]
+
+{ #category : 'hooks' }
+FASTCFGTVisitor >> preConditonalsBranchesVisitOf: aConditionalBlock [
+	"No-op - hook"
+
+	
+]
+
+{ #category : 'accessing' }
+FASTCFGTVisitor >> stoppingBlocks [
+
+	^ stoppingBlocks ifNil: [ stoppingBlocks := OrderedCollection new ]
+]
+
 { #category : 'visiting' }
 FASTCFGTVisitor >> visit: aCFGBlockOrFASTEntity [
 
 	(self visitedBlocks includes: aCFGBlockOrFASTEntity) ifTrue: [ ^ self ]. "Breaking the visit if it was already visited"
+	(self stoppingBlocks includes: aCFGBlockOrFASTEntity) ifTrue: [ ^ self ]. "When visiting conditionals, we want to visit all the blocks of the conditional before visiting the following blocks. I am here to skip the visit of the following blocks while the conditional is not done. Then the conditional will start again the visit from its merge block."
 	^ aCFGBlockOrFASTEntity ifNotNil: [ aCFGBlockOrFASTEntity accept: self ]
 ]
 
@@ -33,10 +69,20 @@ FASTCFGTVisitor >> visitCFGAbstractBlock: aBlock [
 { #category : 'visiting' }
 FASTCFGTVisitor >> visitCFGAbstractConditionalBlock: aBlock [
 
+	| mergeBlock |
 	self visitCFGAbstractBlock: aBlock.
 
-	self flag: #todo. "We should change the order of the visit to visit all the blocks of the conditional before the ones after the conditional."
-	aBlock nextBlocks do: [ :block | self visit: block ]
+	self preConditonalsBranchesVisitOf: aBlock.
+	self stoppingBlocks add: (mergeBlock := aBlock mergeBlock).
+
+	aBlock nextBlocks do: [ :block |
+			self preConditonalsBranchVisitOf: block conditional: aBlock.
+			self visit: block.
+			self postConditonalsBranchVisitOf: block conditional: aBlock ].
+
+	self stoppingBlocks remove: mergeBlock.
+	self postConditonalsBranchesVisitOf: aBlock.
+	self visit: mergeBlock
 ]
 
 { #category : 'visiting' }


### PR DESCRIPTION
Instead of doing a visit depth first, I visit a full conditional block before visiting the following blocks. Then I restart the visit from the merge point. 

I also added hooks to avoid code duplication if we need to add behavior during the visit 